### PR TITLE
Add upgrading instructions for v2.0

### DIFF
--- a/docs-book/master_middleman/source/subnavs/gcp-sdn_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/gcp-sdn_subnav.erb
@@ -13,6 +13,10 @@
       </li>
 
       <li>
+        <a href="/gcp-sdn/upgrading.html">Upgrading GCP Stackdriver Nozzle for PCF</a>
+      </li>
+
+      <li>
         <a href="/gcp-sdn/using.html">Using GCP Stackdriver Nozzle for PCF</a>
       </li>
 

--- a/docs-content/upgrading-clear-metrics-descriptors.html.md.erb
+++ b/docs-content/upgrading-clear-metrics-descriptors.html.md.erb
@@ -1,0 +1,48 @@
+---
+title: Upgrading GCP Stackriver Nozzle for PCF: Clearing Metric Descriptors
+owner: Partners
+---
+
+# Clearing Project Metric Descriptors
+
+This procedure will delete all custom metric descriptors in your Stackdriver Monitoring project.
+This results in historical data loss and the need to re-create dashboards.
+
+## Prerequisites
+- [Golang 1.9+](https://golang.org/doc/install)
+- [BOSH-CLI 2.0.48+](https://bosh.io/docs/cli-v2.html#install) (if using the `stackdriver-tools` BOSH release)
+- [Google Cloud SDK](https://cloud.google.com/sdk/downloads)
+
+## 1. Authenticate with Google Cloud SDK
+Authenticate with an account that has `roles/monitoring.admin` to the Stackdriver Monitoring project
+and setup your application default credentials.
+
+```bash
+gcloud auth login
+gcloud auth appliaction-default login
+```
+
+## 2. Fetch clear-metrics-descriptors source
+```bash
+go get -d github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle
+```
+
+## 3. Stop all instance of stackdriver-nozzle
+All copies of the `stackdriver-nozzle` need to be completely stopped before proceeding. If an instance
+is left running then old metric descriptors will be recreated.
+
+Follow [these instructions](https://docs.pivotal.io/pivotalcf/2-0/customizing/add-delete.html) to delete the
+GCP Stackdriver Nozzle for PCF product from Operations Manager and apply changes to your deployment.
+
+## 4. Clear Metric Descriptors
+Enter the directory with the clear-metrics-descriptors tool:
+```bash
+cd $(go env GOPATH)/src/github.com/cloudfoundry-community/stackdriver-tools/src/stackdriver-nozzle/cmd
+```
+
+Fill in your GCP Project in the following command and execute the tool:
+```bash
+go run ./clear-metrics-descriptors.go --project-id <your GCP project, eg cf-prod-logs>
+```
+
+Your project should now be clear of all custom metric descriptors. You can proceed with [installing](installing.html) the nozzle.

--- a/docs-content/upgrading.html.md.erb
+++ b/docs-content/upgrading.html.md.erb
@@ -1,0 +1,54 @@
+---
+title: Upgrading GCP Stackdriver Nozzle for PCF
+owner: Partners
+---
+
+This topic describes how to upgrade GCP Stackdriver Nozzle for Pivotal Cloud Foundry (PCF) to v2.0 from a v1.x release.
+
+<p class="note warning"><strong>WARNING:</strong>
+This release introduces significant breaking changes for Stackdriver Nozzle users. These changes
+require the operator to take manual steps as part of the upgrading process. The manual steps
+will reset aspects of the project and will result in irreversible historical data loss and the need to
+recreate dashboards.
+</p>
+
+
+## Stackdriver Monitoring Changes
+All exported metrics have changed in this release.
+
+Metric changes:
+
+  - Metrics derived from the firehose now have the metric origin prefixed to the metric name, e.g. "gorouter.total_requests".
+  - Metrics derived from the firehose are now exported under a configurable path prefix, which defaults to "firehose".
+  - CounterEvent metrics are now represented as COUNTERs rather than GAUGEs in Stackdriver, so per-second rates can be computed.
+  - The nozzle exports its own custom metrics under the "stackdriver-nozzle" prefix.
+
+Label changes:
+
+  - Application, space and organization UUIDs are no longer exported.
+  - Resolved application, space and organization names are concatenated into a single "applicationPath" label.
+  - The application instance index is now exported.
+  - Event envelope tags are now exported as a string of comma-separated key=value pairs.
+  - Origin and EventType labels are only attached to logs, not metrics.
+  - There is a new "foundation" label that is configurable per nozzle instance, to distinguish between multiple foundations in a GCP / Stackdriver project.
+
+## Clear Metric Descriptors
+Follow [this guide](upgrading-clear-metrics-descriptors.html) to reset metric descriptors
+for your Stackdriver Monitoring project. This needed is to stay under the default [custom metric descriptor](https://cloud.google.com/monitoring/custom-metrics/) quota.
+Ensure the `stackdriver-nozzle` is not running during this process.
+
+An alternative to this procedure is to provision a new Google Cloud Project and configure the updated `stackdriver-nozzle` release to use it.
+
+## Singleton Deployment of stackdriver-nozzle
+The `stackdriver-nozzle` keeps track of counter metrics to send to Stackdriver Monitoring at the instance level by default.
+If multiple copies of the `stackdriver-nozzle` are reporting the same metrics for a Cloud Foundry deployment they
+will report incorrect data. This issue is mitigated by running a single instance of the nozzle.
+An upstream feature in Loggregator is being [tracked](https://www.pivotaltracker.com/n/projects/993188/stories/154821450) to address this.
+
+Operations Manager/Tile users are forced to run the `stackdriver-nozzle` job as a single instance.
+
+Users are encouraged to vertically scale the `stackdriver-nozzle` VM in case of resource saturation. A number of performance optimizations in this release make sure
+that a single instance of the nozzle is able to provide enough throughput for a medium sized PCF installation.
+
+If you find the need to scale the `stackdriver-nozzle` job horizontally you must use the [BOSH release](https://github.com/cloudfoundry-community/stackdriver-tools)
+and follow guidance for the [2.0 upgrade](https://github.com/cloudfoundry-community/stackdriver-tools/blob/develop/docs/upgrading_2.0.md#singleton-deployment-of-stackdriver-nozzle).


### PR DESCRIPTION
This change adds upgrade instructions for v2.0. This version is not yet released and the PivNet docs should not be updated until it is (~late next week).

related: cloudfoundry-community/stackdriver-tools/issues/185